### PR TITLE
clarified instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/MXkmCTywFFM?rel=0&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
 
+**Note**: `cd` into the `lecture_kit` directory before running any commands
+like `bundle`, `rake`, etc.
+
 ## ERD
 
 Currently, our ERD looks as following:


### PR DESCRIPTION
closes #1 

Hi, thanks for submitting the issue.

The structure is supposed to be like this for this particular lesson but we've added a note to `cd` into the specific directory for clarification.

Thanks again for submitting this issue and helping us improve the curriculum!